### PR TITLE
Add download_ckpt_v2

### DIFF
--- a/poto/ckpt.py
+++ b/poto/ckpt.py
@@ -42,6 +42,55 @@ def download_ckpt(s3, ckpt_dir, training=False):
                         bucket_name='checkpoints',
                         object_name=os.path.join(ckpt_dir, "{}-{}.{}".format(MODEL_FILENAME, latest_step, extension)))
 
+def download_ckpt_v2(s3, ckpt_dir, training=False):
+    """Download latest ckpt from S3. 
+       You don't have to pass ckpt_dir as `checkpoints/`
+       That is different with `download_ckpt`
+
+    Args:
+        s3: Verified s3 client object from boto
+        ckpt_dir: checkpoints dir contains `checkpoints`
+        training: using this function as training mode or inference mode
+    
+    Returns:
+        None
+    """
+    if ckpt_dir[-1] != '/':
+        ckpt_dir += '/'
+    
+    splited = ckpt_dir.split('/')
+    start_idx = -1
+    for i, path in enumerate(splited):
+        if path == 'checkpoints':
+            start_idx = i
+
+    assert start_idx != -1 , f"{ckpt_dir} doesn't contain `checkpoints`"
+
+    prefix = "/".join(splited[start_idx:])
+    
+    try:
+        objects = list_object_specific(s3, 'checkpoints', prefix)
+    except KeyError as e:
+        if training:
+            return None
+        else:
+            raise KeyError(e)
+    else:
+        try:
+            os.makedirs(ckpt_dir)
+        except OSError:
+            print('Dir already exists.')
+        latest_step = max(get_ckpt_steps(objects))
+        ckpt_prefix = os.path.join(prefix, 'checkpoint')
+        local_file_path = os.path.join(ckpt_dir, 'checkpoint')
+        download_file(s3, 'checkpoints', object_name=ckpt_prefix, local_file_path=local_file_path)
+        for extension in CKPT_EXTENSIONS:
+            file_ = f"{MODEL_FILENAME}-{latest_step}.{extension}"
+            download_file(s3=s3,
+                        bucket_name='checkpoints',
+                        object_name=os.path.join(prefix, file_),
+                        local_file_path=os.path.join(ckpt_dir, file_))
+
 def get_ckpt_steps(objects):
     return np.unique([int(obj.split(CKPT_START)[-1].split('.')[0])
                       for obj in objects if re.search(CKPT_START, obj)])


### PR DESCRIPTION
## 목적
- melyDLF에서 로컬에 checkpoints가 없어도 object storage에서 다운로드 받을 수 있게 만듭니다.
- 이전에도 가능했지만 로컬에 checkpoints가 있어도 상대경로여서 실행하는 path에 따라 ckpt_dir이 바뀌었기 때문에 문제가 되서 결국 사용하기가 어려워 변경했습니다.

## 변경 사항
- ckpt_dir이 꼭 `checkpoints/`가 아니여도 되도록 `download_ckpt_v2`를 추가했습니다.
- flowbox같은 다른 프로젝트들의 디펜던시를 위해 기존 버전은 그대로 두었습니다.